### PR TITLE
Update deprecated react create class and prop types

### DIFF
--- a/dist/leafletmap.js
+++ b/dist/leafletmap.js
@@ -25,6 +25,7 @@ var TILE_LAYER_URL = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png
 var ATTRIBUTION = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
 var AMSTERDAM = [52.374030, 4.8896900]; // Amsterdam
 var SELECTED_MARKER_CLASSNAME = "custom-leaflet-marker-selected";
+var zIndex;
 
 var Utils = {
   getStandardDeviation: function getStandardDeviation(values, mean) {
@@ -44,7 +45,7 @@ var LeafletMap = function LeafletMap() {
 
 LeafletMap.prototype = {
   init: function init(id) {
-    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     this.options = _lodash2["default"].assign({
       zoom: 6,
@@ -77,6 +78,7 @@ LeafletMap.prototype = {
     }
 
     if (data.features.length) {
+      zIndex = data.features.length;
       this.postingBounds = this.getBounds(data.features);
 
       this.geojson = _leaflet2["default"].geoJson(data, {
@@ -143,8 +145,8 @@ LeafletMap.prototype = {
   },
 
   getDistance: function getDistance() {
-    var from = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
-    var to = arguments.length <= 1 || arguments[1] === undefined ? [] : arguments[1];
+    var from = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+    var to = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
 
     return Math.round(_leaflet2["default"].latLng.apply(_leaflet2["default"], from.reverse()).distanceTo(_leaflet2["default"].latLng.apply(_leaflet2["default"], to.reverse()))) || 0.01;
   },
@@ -169,7 +171,7 @@ LeafletMap.prototype = {
   },
 
   toggleMarkerSelected: function toggleMarkerSelected(marker) {
-    var options = arguments.length <= 1 || arguments[1] === undefined ? { on: true } : arguments[1];
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { on: true };
 
     if (marker && marker._icon) {
       marker._icon.classList[options.on ? "add" : "remove"](SELECTED_MARKER_CLASSNAME);
@@ -197,7 +199,9 @@ LeafletMap.prototype = {
     });
 
     marker = _leaflet2["default"].marker(latlng, {
-      icon: icon
+      icon: icon,
+      riseOnHover: true,
+      zIndexOffset: zIndex--
     });
 
     radius = (this.getDistance(feature.geometry.coordinates, feature.properties.top_left) / 1000).toFixed(2);

--- a/dist/map.js
+++ b/dist/map.js
@@ -8,6 +8,14 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require("create-react-class");
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 var _leafletmap = require("./leafletmap");
 
 var _leafletmap2 = _interopRequireDefault(_leafletmap);
@@ -18,15 +26,15 @@ var _lodash2 = _interopRequireDefault(_lodash);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-exports["default"] = _react2["default"].createClass({
+exports["default"] = (0, _createReactClass2["default"])({
   displayName: "Geo Visualization React Component",
 
   propTypes: {
-    id: _react2["default"].PropTypes.string.isRequired,
-    data: _react2["default"].PropTypes.object,
-    onMove: _react2["default"].PropTypes.func,
-    onIconClick: _react2["default"].PropTypes.func,
-    onDeselect: _react2["default"].PropTypes.func
+    id: _propTypes2["default"].string.isRequired,
+    data: _propTypes2["default"].object,
+    onMove: _propTypes2["default"].func,
+    onIconClick: _propTypes2["default"].func,
+    onDeselect: _propTypes2["default"].func
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "color": "^0.11.1",
+    "create-react-class": "15.6.3",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-util": "^3.0.7",
     "leaflet": "^0.7.7 ",
     "lodash": "^4.6.0",
+    "prop-types": "15.6.0",
     "react": ">0.13.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/src/map.jsx
+++ b/src/map.jsx
@@ -1,16 +1,18 @@
 import React from "react";
+import PropTypes from "prop-types";
+import createReactClass from "create-react-class";
 import LeafletMap from "./leafletmap";
 import _ from "lodash";
 
-export default React.createClass({
+export default createReactClass({
   displayName: "Geo Visualization React Component",
 
   propTypes: {
-    id: React.PropTypes.string.isRequired,
-    data: React.PropTypes.object,
-    onMove: React.PropTypes.func,
-    onIconClick: React.PropTypes.func,
-    onDeselect: React.PropTypes.func
+    id: PropTypes.string.isRequired,
+    data: PropTypes.object,
+    onMove: PropTypes.func,
+    onIconClick: PropTypes.func,
+    onDeselect: PropTypes.func
   },
 
   getDefaultProps: function () {


### PR DESCRIPTION
This will update the deprecated React.createClass and React.PropType.
The current Master is also missing some changes that were made earlier by thefakegm. these are also in here.